### PR TITLE
chore: migrate to workload contract

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: lib-chart
   repository: oci://ghcr.io/orhayoun-eevee
-  version: 0.0.11
-digest: sha256:de6d600ff7a89a6bdf0ef9c50501f4a3ccb3dc7712f60e43b278f4c66b147287
-generated: "2026-03-04T16:46:36.058984702Z"
+  version: 0.0.14
+digest: sha256:b8d546a88d3e61c4673866ba0ac71fef0aff5310c416a0b8a5958b252de98289
+generated: "2026-05-03T15:26:44.504877+03:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: sonarr
 description: A Helm chart for Sonarr using lib-chart
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "4.0.16.2944"
 keywords:
   - sonarr
   - media-center
 dependencies:
   - name: lib-chart
-    version: "0.0.11"
+    version: "0.0.14"
     repository: "oci://ghcr.io/orhayoun-eevee"
 maintainers:
   - name: Sonarr Team

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sonarr Helm Chart
 
-This chart deploys Sonarr using the shared dependency `lib-chart` (`0.0.7`).
+This chart deploys Sonarr using the shared dependency `lib-chart` (`0.0.14`).
 
 ## Installation
 
@@ -10,7 +10,7 @@ helm install sonarr . --namespace media-center
 
 ## Dependencies
 
-- `lib-chart` (`0.0.7`) from `oci://ghcr.io/orhayoun-eevee`
+- `lib-chart` (`0.0.14`) from `oci://ghcr.io/orhayoun-eevee`
 
 Update dependencies from chart root:
 

--- a/tests/scenarios/overrides.yaml
+++ b/tests/scenarios/overrides.yaml
@@ -12,11 +12,12 @@ network:
           metrics:
             port: 9200
 
-deployment:
-  replicas: 2
-  podSecurityContext:
-    fsGroup: 2000
-  containers:
-    sonarr:
-      securityContext:
-        runAsUser: 2001
+workload:
+  spec:
+    replicas: 2
+    podSecurityContext:
+      fsGroup: 2000
+    containers:
+      sonarr:
+        securityContext:
+          runAsUser: 2001

--- a/tests/snapshots/full.yaml
+++ b/tests/snapshots/full.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -209,11 +209,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.8
+        helm.sh/chart: sonarr-0.0.9
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 1011
@@ -421,7 +422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -450,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -479,7 +480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -508,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   host: sonarr-http
   trafficPolicy:
@@ -537,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   instanceSelector:
     matchLabels:
@@ -559,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -570,17 +571,16 @@ spec:
   hostnames:
     - sonarr-k8s.orhayoun.com
   rules:
-    -
+    - backendRefs:
+      - group: ""
+        kind: Service
+        name: sonarr-http
+        port: 8080
+        weight: 100
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: sonarr-http
-          port: 8080
-          weight: 100
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: sonarr/templates/all.yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -605,16 +605,15 @@ spec:
   hostnames:
     - sonarr-k8s.orhayoun.com
   rules:
-    -
+    - filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - requestRedirect:
-            scheme: https
-            statusCode: 301
-          type: RequestRedirect
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: sonarr/templates/all.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -628,7 +627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   groups:
     - name: sonarr.rules
@@ -828,7 +827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:

--- a/tests/snapshots/minimal.yaml
+++ b/tests/snapshots/minimal.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -183,11 +183,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.8
+        helm.sh/chart: sonarr-0.0.9
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 1011

--- a/tests/snapshots/overrides.yaml
+++ b/tests/snapshots/overrides.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   replicas: 2
   revisionHistoryLimit: 3
@@ -209,11 +209,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.8
+        helm.sh/chart: sonarr-0.0.9
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr
     spec:
+      
       terminationGracePeriodSeconds: 60
       securityContext:
         fsGroup: 2000
@@ -421,7 +422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -450,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -479,7 +480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:
@@ -508,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   host: sonarr-http
   trafficPolicy:
@@ -537,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   instanceSelector:
     matchLabels:
@@ -559,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -570,17 +571,16 @@ spec:
   hostnames:
     - sonarr-k8s.orhayoun.com
   rules:
-    -
+    - backendRefs:
+      - group: ""
+        kind: Service
+        name: sonarr-http
+        port: 8080
+        weight: 100
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - group: ""
-          kind: Service
-          name: sonarr-http
-          port: 8080
-          weight: 100
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: sonarr/templates/all.yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -605,16 +605,15 @@ spec:
   hostnames:
     - sonarr-k8s.orhayoun.com
   rules:
-    -
+    - filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
       matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - requestRedirect:
-            scheme: https
-            statusCode: 301
-          type: RequestRedirect
+      - path:
+          type: PathPrefix
+          value: /
 ---
 # Source: sonarr/templates/all.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -628,7 +627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   groups:
     - name: sonarr.rules
@@ -828,7 +827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.8
+    helm.sh/chart: sonarr-0.0.9
 spec:
   selector:
     matchLabels:

--- a/tests/sonarr_contract_test.yaml
+++ b/tests/sonarr_contract_test.yaml
@@ -38,23 +38,33 @@ tests:
 
   - it: wires sonarr application container security and pvc correctly
     asserts:
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].name
           value: sonarr
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].securityContext.readOnlyRootFilesystem
           value: true
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].securityContext.runAsUser
           value: 1012
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].securityContext.runAsGroup
           value: 1011
-      - documentIndex: 14
+      - documentSelector:
+          path: kind
+          value: PersistentVolumeClaim
         equal:
           path: metadata.name
           value: sonarr-config
@@ -145,14 +155,17 @@ tests:
 
   - it: applies explicit sonarr image override for controlled rollouts
     set:
-      deployment:
-        containers:
-          sonarr:
-            image:
-              repository: registry.internal/sonarr
-              tag: ci-test
+      workload:
+        spec:
+          containers:
+            sonarr:
+              image:
+                repository: registry.internal/sonarr
+                tag: ci-test
     asserts:
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].image
           value: registry.internal/sonarr:ci-test
@@ -171,19 +184,27 @@ tests:
         equal:
           path: spec.ports[0].targetPort
           value: metrics
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].livenessProbe.httpGet.path
           value: /ping
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].readinessProbe.httpGet.path
           value: /ping
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: sonarr-config
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: IfNotPresent

--- a/tests/sonarr_service_overrides_test.yaml
+++ b/tests/sonarr_service_overrides_test.yaml
@@ -66,14 +66,17 @@ tests:
 
   - it: applies app timezone env override
     set:
-      deployment:
-        containers:
-          sonarr:
-            env:
-              - name: TZ
-                value: Europe/Berlin
+      workload:
+        spec:
+          containers:
+            sonarr:
+              env:
+                - name: TZ
+                  value: Europe/Berlin
     asserts:
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].env[0].value
           value: Europe/Berlin

--- a/tests/sonarr_workload_overrides_test.yaml
+++ b/tests/sonarr_workload_overrides_test.yaml
@@ -2,10 +2,11 @@ suite: sonarr workload overrides
 templates:
   - templates/all.yaml
 tests:
-  - it: applies deployment replica override
+  - it: applies workload replica override
     set:
-      deployment:
-        replicas: 2
+      workload:
+        spec:
+          replicas: 2
     asserts:
       - documentSelector:
           path: kind
@@ -16,9 +17,10 @@ tests:
 
   - it: applies pod security context fsGroup override
     set:
-      deployment:
-        podSecurityContext:
-          fsGroup: 2000
+      workload:
+        spec:
+          podSecurityContext:
+            fsGroup: 2000
     asserts:
       - documentSelector:
           path: kind
@@ -43,27 +45,33 @@ tests:
 
   - it: applies container cpu limit override
     set:
-      deployment:
-        containers:
-          sonarr:
-            resources:
-              limits:
-                cpu: 750m
+      workload:
+        spec:
+          containers:
+            sonarr:
+              resources:
+                limits:
+                  cpu: 750m
     asserts:
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].resources.limits.cpu
           value: 750m
 
   - it: applies container security context runAsUser override
     set:
-      deployment:
-        containers:
-          sonarr:
-            securityContext:
-              runAsUser: 2001
+      workload:
+        spec:
+          containers:
+            sonarr:
+              securityContext:
+                runAsUser: 2001
     asserts:
-      - documentIndex: 1
+      - documentSelector:
+          path: kind
+          value: Deployment
         equal:
           path: spec.template.spec.containers[1].securityContext.runAsUser
           value: 2001

--- a/values.yaml
+++ b/values.yaml
@@ -230,232 +230,234 @@ network:
 
 
 # ----------------------------------------------------------------------------
-# Deployment Configuration
+# Workload Configuration
 # ----------------------------------------------------------------------------
-deployment:
-  replicas: 1
-  strategy:
-    type: Recreate
-  revisionHistoryLimit: 3
-  terminationGracePeriodSeconds: 60
-  dnsPolicy: ClusterFirst
-  enableServiceLinks: false
-  automountServiceAccountToken: false
+workload:
+  type: deployment
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    revisionHistoryLimit: 3
+    terminationGracePeriodSeconds: 60
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: false
+    automountServiceAccountToken: false
 
-  # Pod labels
-  podLabels:
-    app.kubernetes.io/part-of: media-center
-    logging.kubernetes.io/component: media-center
-    logging.kubernetes.io/service: sonarr
+    # Pod labels
+    podLabels:
+      app.kubernetes.io/part-of: media-center
+      logging.kubernetes.io/component: media-center
+      logging.kubernetes.io/service: sonarr
 
-  # Node selector to ensure pods only schedule on Linux nodes
-  nodeSelector:
-    kubernetes.io/os: linux
+    # Node selector to ensure pods only schedule on Linux nodes
+    nodeSelector:
+      kubernetes.io/os: linux
 
-  # Pod security context
-  podSecurityContext:
-    fsGroup: 1011
-    fsGroupChangePolicy: OnRootMismatch
-    runAsNonRoot: true
-    supplementalGroups:
-      - 1010  # downloads group for NFS access
-      - 1003  # media-nfs group for NFS access
+    # Pod security context
+    podSecurityContext:
+      fsGroup: 1011
+      fsGroupChangePolicy: OnRootMismatch
+      runAsNonRoot: true
+      supplementalGroups:
+        - 1010  # downloads group for NFS access
+        - 1003  # media-nfs group for NFS access
 
-  # Main container configuration
-  # NOTE: Container name 'sonarr' matches dashboard queries (container="sonarr")
-  # Application-v2 requires explicit container definitions (no defaults)
-  containers:
-    sonarr:
-      enabled: true
-      image:
-        repository: ghcr.io/runlix/sonarr
-        tag: "release-4.0.16.2944-latest@sha256:7aefee37afd5d5567e5c591067be95d1a95759b75569148bfdd43dbe46b97c50"
-        pullPolicy: IfNotPresent
+    # Main container configuration
+    # NOTE: Container name 'sonarr' matches dashboard queries (container="sonarr")
+    # Application-v2 requires explicit container definitions (no defaults)
+    containers:
+      sonarr:
+        enabled: true
+        image:
+          repository: ghcr.io/runlix/sonarr
+          tag: "release-4.0.16.2944-latest@sha256:7aefee37afd5d5567e5c591067be95d1a95759b75569148bfdd43dbe46b97c50"
+          pullPolicy: IfNotPresent
 
-      env:
-        - name: TZ
-          value: "UTC"
-        - name: SONARR__SERVER__PORT
-          value: "8080"
-        - name: SONARR__SERVER__BINDADDRESS
-          value: "0.0.0.0"
+        env:
+          - name: TZ
+            value: "UTC"
+          - name: SONARR__SERVER__PORT
+            value: "8080"
+          - name: SONARR__SERVER__BINDADDRESS
+            value: "0.0.0.0"
 
-      ports:
-        - containerPort: 8080
-          name: http
-          protocol: TCP
+        ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
 
-      volumeMounts:
-        - name: config
-          mountPath: /config
-        - name: media
-          mountPath: /media
-        - name: media-old
-          mountPath: /media-old
-        - name: downloads
-          mountPath: /downloads
-        - name: backup
-          mountPath: /backup
-        - name: tmp
-          mountPath: /tmp
+        volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: media
+            mountPath: /media
+          - name: media-old
+            mountPath: /media-old
+          - name: downloads
+            mountPath: /downloads
+          - name: backup
+            mountPath: /backup
+          - name: tmp
+            mountPath: /tmp
 
-      # Health Probes
-      livenessProbe:
-        httpGet:
-          path: /ping
-          port: http
-          scheme: HTTP
-        failureThreshold: 3
-        initialDelaySeconds: 30
-        periodSeconds: 30
-        successThreshold: 1
-        timeoutSeconds: 5
+        # Health Probes
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
 
-      readinessProbe:
-        httpGet:
-          path: /ping
-          port: http
-          scheme: HTTP
-        failureThreshold: 3
-        initialDelaySeconds: 15
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
 
-      startupProbe:
-        httpGet:
-          path: /ping
-          port: http
-          scheme: HTTP
-        failureThreshold: 30
-        initialDelaySeconds: 10
-        periodSeconds: 5
-        successThreshold: 1
-        timeoutSeconds: 5
+        startupProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          failureThreshold: 30
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
 
-      # Container Security Context (main container override)
-      securityContext:
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 1012  # Matches Sonarr PUID
-        runAsGroup: 1011  # Matches Sonarr PGID
-        allowPrivilegeEscalation: false
-        privileged: false
-        appArmorProfile:
-          type: RuntimeDefault
-        capabilities:
-          drop:
-            - ALL
-        seccompProfile:
-          type: RuntimeDefault
+        # Container Security Context (main container override)
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1012  # Matches Sonarr PUID
+          runAsGroup: 1011  # Matches Sonarr PGID
+          allowPrivilegeEscalation: false
+          privileged: false
+          appArmorProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
-      # Resources
-      resources:
-        requests:
-          cpu: 500m
-          memory: 256Mi
-          ephemeral-storage: 2Gi
-        limits:
-          cpu: 500m
-          memory: 1Gi
-          ephemeral-storage: 2Gi
+        # Resources
+        resources:
+          requests:
+            cpu: 500m
+            memory: 256Mi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+            ephemeral-storage: 2Gi
 
-    # Metrics exporter container (Exportarr)
-    exportarr:
-      enabled: true
-      image:
-        repository: ghcr.io/orhayoun/exportarr
-        tag: "v2.3.1@sha256:2650f6a501b1d691daf5dfe758068f44336d0bb1d443f9db2c94900244d423bc"
-        pullPolicy: IfNotPresent
+      # Metrics exporter container (Exportarr)
+      exportarr:
+        enabled: true
+        image:
+          repository: ghcr.io/orhayoun/exportarr
+          tag: "v2.3.1@sha256:2650f6a501b1d691daf5dfe758068f44336d0bb1d443f9db2c94900244d423bc"
+          pullPolicy: IfNotPresent
 
-      args:
-        - "sonarr"
+        args:
+          - "sonarr"
 
-      env:
-        - name: URL
-          value: http://localhost:8080
-        - name: CONFIG
-          value: /config/config.xml
-        - name: PORT
-          value: "9100"
-        - name: ENABLE_ADDITIONAL_METRICS
-          value: "false"
-        - name: ENABLE_UNKNOWN_QUEUE_ITEMS
-          value: "false"
+        env:
+          - name: URL
+            value: http://localhost:8080
+          - name: CONFIG
+            value: /config/config.xml
+          - name: PORT
+            value: "9100"
+          - name: ENABLE_ADDITIONAL_METRICS
+            value: "false"
+          - name: ENABLE_UNKNOWN_QUEUE_ITEMS
+            value: "false"
 
-      ports:
-        - containerPort: 9100
-          name: metrics
-          protocol: TCP
+        ports:
+          - containerPort: 9100
+            name: metrics
+            protocol: TCP
 
-      volumeMounts:
-        - name: config
-          mountPath: /config
-          readOnly: true
+        volumeMounts:
+          - name: config
+            mountPath: /config
+            readOnly: true
 
-      # Health Probes
-      livenessProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 30
-        periodSeconds: 30
-        timeoutSeconds: 5
-        failureThreshold: 3
-        successThreshold: 1
+        # Health Probes
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
 
-      readinessProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 10
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-        successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
 
-      startupProbe:
-        httpGet:
-          path: /metrics
-          port: metrics
-          scheme: HTTP
-        initialDelaySeconds: 45  # MONITORING: Allow time for Sonarr to be ready
-        # Exporter depends on: (1) Sonarr config.xml file, (2) Sonarr service at localhost:8080
-        # Sonarr startup probe allows up to 160s (10s + 30*5s), so 45s initial delay ensures Sonarr is likely ready
-        periodSeconds: 10  # MONITORING: Check every 10s to reduce probe frequency during startup
-        timeoutSeconds: 10  # MONITORING: Longer timeout allows exporter time to connect to Sonarr and respond
-        # Exporter may be slow to respond while still connecting to Sonarr API or initializing metrics collection
-        failureThreshold: 30  # MONITORING: Allow up to 5 minutes total startup time (45s + 30*10s = 345s)
-        # Provides sufficient time for exporter to initialize, connect to Sonarr, and start serving metrics
-        successThreshold: 1
+        startupProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 45  # MONITORING: Allow time for Sonarr to be ready
+          # Exporter depends on: (1) Sonarr config.xml file, (2) Sonarr service at localhost:8080
+          # Sonarr startup probe allows up to 160s (10s + 30*5s), so 45s initial delay ensures Sonarr is likely ready
+          periodSeconds: 10  # MONITORING: Check every 10s to reduce probe frequency during startup
+          timeoutSeconds: 10  # MONITORING: Longer timeout allows exporter time to connect to Sonarr and respond
+          # Exporter may be slow to respond while still connecting to Sonarr API or initializing metrics collection
+          failureThreshold: 30  # MONITORING: Allow up to 5 minutes total startup time (45s + 30*10s = 345s)
+          # Provides sufficient time for exporter to initialize, connect to Sonarr, and start serving metrics
+          successThreshold: 1
 
-      # Container Security Context
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 65534  # nobody user
-        runAsGroup: 65534
-        appArmorProfile:
-          type: RuntimeDefault
-        capabilities:
-          drop:
-            - ALL
-        seccompProfile:
-          type: RuntimeDefault
+        # Container Security Context
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534  # nobody user
+          runAsGroup: 65534
+          appArmorProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
-      # Resources
-      resources:
-        requests:
-          cpu: 10m
-          memory: 32Mi
-          ephemeral-storage: 100Mi
-        limits:
-          cpu: 100m
-          memory: 64Mi
-          ephemeral-storage: 100Mi
+        # Resources
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+            ephemeral-storage: 100Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+            ephemeral-storage: 100Mi
 
 # ----------------------------------------------------------------------------
 # Feature: Persistence


### PR DESCRIPTION
## Summary
- migrate Sonarr values, scenarios, and unit tests from top-level deployment keys to workload.type/spec
- bump lib-chart to 0.0.14 and refresh Chart.lock
- regenerate snapshots and align README dependency references

## Validation
- scripts/chart-ci.sh sonarr-helm