### PR TITLE
ci: normalize renovate snapshot wrapper

### DIFF
--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -3,22 +3,28 @@ name: Renovate Snapshot Update
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
+    branches: [main]
     paths:
+      # Keep the trigger on render inputs only. `tests/snapshots/**` stays out
+      # of scope so the bot does not retrigger itself after committing updates.
+      - "Chart.yaml"
+      - "Chart.lock"
       - "values.yaml"
+      - "templates/**"
+      - "charts/**"
+      - "tests/scenarios/**"
 
 permissions:
   contents: write
   packages: read
 
 concurrency:
-  group: renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
+  group: caller-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   update-snapshots:
-    if: github.actor == 'renovate[bot]' && github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.31
     with:
       snapshots_dir: tests/snapshots

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This chart follows the same reusable 5-layer validation pipeline used by `helm-c
 
 - Required gate: `.github/workflows/pr-required-checks.yaml` (thin wrapper around centralized `pr-required-checks-chart.yaml` in `build-workflow`; this is the only automatic PR gate)
 - Release: `.github/workflows/on-tag.yaml` -> `build-workflow/.github/workflows/release-chart.yaml` (includes keyless signing/attestation)
-- Renovate snapshot updates: `.github/workflows/renovate-snapshot-update.yaml` (Renovate PRs touching `values.yaml`)
+- Renovate snapshot updates: `.github/workflows/renovate-snapshot-update.yaml` (Renovate PRs touching render inputs)
 - Renovate config validation: `.github/workflows/renovate-config.yaml` (automatic on matching config changes; supports `workflow_dispatch`)
 - Code scanning: `.github/workflows/codeql.yaml` (centralized reusable workflow in `build-workflow`; automatic on push/schedule and manual via `workflow_dispatch`)
 
 Trigger behavior:
 - `pr-required-checks.yaml`: automatic on every PR to `main` and `merge_group` (`checks_requested`) (require this status in branch protection)
 - `on-tag.yaml`: automatic on `v*` tag push
-- `renovate-snapshot-update.yaml`: automatic for Renovate PRs when `values.yaml` changes
+- `renovate-snapshot-update.yaml`: automatic for Renovate PRs when render inputs change
 - `renovate-config.yaml`: automatic on push to `main` when Renovate config files change, plus manual `workflow_dispatch`
 - `codeql.yaml`: automatic on push to `main` for CI automation/chart paths, weekly schedule, plus manual `workflow_dispatch`
 
@@ -108,4 +108,4 @@ Recommended contexts:
 - `PR Required Checks / ci-required / ci-required (pull_request)`
 - `PR Required Checks / ci-required / ci-required (merge_group)`
 
-For Renovate PRs that change `values.yaml`, `.github/workflows/renovate-snapshot-update.yaml` runs `make snapshot-update` and commits updated `tests/snapshots/*` back to the PR branch so strict snapshot checks remain enforced.
+For Renovate PRs that change render inputs (`Chart.yaml`, `Chart.lock`, `values.yaml`, `templates/`, `charts/`, or `tests/scenarios/`), `.github/workflows/renovate-snapshot-update.yaml` runs `make snapshot-update` and commits updated `tests/snapshots/*` back to the PR branch so strict snapshot checks remain enforced.


### PR DESCRIPTION
## Summary\n- broaden Renovate snapshot-update triggers to render inputs\n- remove stale caller-side bot guard and delegate trusted-bot checks to build-workflow v0.1.31\n- update README wording\n\n## Validation\n- GitHub required checks\n\nLocal note: scripts/chart-ci.sh sonarr-helm could not run because the local Docker daemon is unavailable.