### PR TITLE
ci: adopt build workflow v0.1.34

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish-chart:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.33
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.34
     with:
       chart_path: .
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -33,9 +33,9 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.33
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.34
     with:
       chart_kind: app
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.33
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.34

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -25,9 +25,9 @@ concurrency:
 jobs:
   update-snapshots:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.33
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.34
     with:
       snapshots_dir: tests/snapshots
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}


### PR DESCRIPTION
## Summary
- adopt build-workflow v0.1.34 reusable workflow refs
- switch GitHub App token inputs to the GHCR_AUTO_CLIENT_ID contract

## Validation
- canary helm-common-lib PR #64 passed ci-required
- canary jellyfin-helm PR #31 passed ci-required