### PR TITLE
chore: adopt lib-chart 0.0.15

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: lib-chart
   repository: oci://ghcr.io/orhayoun-eevee
-  version: 0.0.14
-digest: sha256:b8d546a88d3e61c4673866ba0ac71fef0aff5310c416a0b8a5958b252de98289
-generated: "2026-05-03T15:26:44.504877+03:00"
+  version: 0.0.15
+digest: sha256:18fe9fff55a5ddef4eeacecdc956ca19a2f84284ceb8b46e620120be80813e2b
+generated: "2026-05-27T20:03:16.079591+03:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: sonarr
 description: A Helm chart for Sonarr using lib-chart
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "4.0.16.2944"
 keywords:
   - sonarr
   - media-center
 dependencies:
   - name: lib-chart
-    version: "0.0.14"
+    version: "0.0.15"
     repository: "oci://ghcr.io/orhayoun-eevee"
 maintainers:
   - name: Sonarr Team

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sonarr Helm Chart
 
-This chart deploys Sonarr using the shared dependency `lib-chart` (`0.0.14`).
+This chart deploys Sonarr using the shared dependency `lib-chart` (`0.0.15`).
 
 ## Installation
 
@@ -10,7 +10,7 @@ helm install sonarr . --namespace media-center
 
 ## Dependencies
 
-- `lib-chart` (`0.0.14`) from `oci://ghcr.io/orhayoun-eevee`
+- `lib-chart` (`0.0.15`) from `oci://ghcr.io/orhayoun-eevee`
 
 Update dependencies from chart root:
 

--- a/tests/snapshots/full.yaml
+++ b/tests/snapshots/full.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -209,7 +209,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.9
+        helm.sh/chart: sonarr-0.0.10
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr
@@ -422,7 +422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -480,7 +480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   host: sonarr-http
   trafficPolicy:
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   instanceSelector:
     matchLabels:
@@ -560,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -627,7 +627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   groups:
     - name: sonarr.rules
@@ -827,7 +827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:

--- a/tests/snapshots/minimal.yaml
+++ b/tests/snapshots/minimal.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -183,7 +183,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.9
+        helm.sh/chart: sonarr-0.0.10
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr

--- a/tests/snapshots/overrides.yaml
+++ b/tests/snapshots/overrides.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   podSelector:
     matchLabels:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center service account
 automountServiceAccountToken: false
@@ -116,7 +116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
   annotations:
     description: Sonarr media center HTTP service
 spec:
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   replicas: 2
   revisionHistoryLimit: 3
@@ -209,7 +209,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: sonarr
         app.kubernetes.io/version: 4.0.16.2944
-        helm.sh/chart: sonarr-0.0.9
+        helm.sh/chart: sonarr-0.0.10
         app.kubernetes.io/part-of: media-center
         logging.kubernetes.io/component: media-center
         logging.kubernetes.io/service: sonarr
@@ -422,7 +422,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -480,7 +480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   host: sonarr-http
   trafficPolicy:
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   instanceSelector:
     matchLabels:
@@ -560,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   parentRefs:
     - name: shared-platform-gateway
@@ -627,7 +627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   groups:
     - name: sonarr.rules
@@ -827,7 +827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sonarr
     app.kubernetes.io/version: 4.0.16.2944
-    helm.sh/chart: sonarr-0.0.9
+    helm.sh/chart: sonarr-0.0.10
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
- bump chart version to 0.0.10
- update lib-chart dependency to 0.0.15
- refresh Chart.lock, snapshots, and README

## Validation
- DOCKER_IMAGE=helm-validate:local BUILD_WORKFLOW=/Users/ohayoun/personal/eevee/build-workflow scripts/chart-ci.sh /private/tmp/eevee-p5-sonarr-lib015