### PR TITLE
ci: adopt build-workflow v0.1.35

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish-chart:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/release-chart.yaml@v0.1.35
     with:
       chart_path: .
       release_environment: production

--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -9,13 +9,6 @@ on:
       - ready_for_review
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'AGENTS.md'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'LICENSE'
   merge_group:
     types:
       - checks_requested
@@ -33,7 +26,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/pr-required-checks-chart.yaml@v0.1.35
     with:
       chart_kind: app
     secrets:

--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -21,4 +21,4 @@ concurrency:
 
 jobs:
   validate:
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.35

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   update-snapshots:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@v0.1.35
     with:
       snapshots_dir: tests/snapshots
     secrets:


### PR DESCRIPTION
## Summary
- update chart workflow wrappers to build-workflow v0.1.35
- remove required-check wrapper paths-ignore so ci-required is reported on docs-only PRs

## Validation
- actionlint .github/workflows/*.yaml
- git diff --check
- local CI: helm-common-lib and jellyfin-helm passed (representative build-workflow propagation gate)